### PR TITLE
Added elements to remove some hardcoded primaryKey field name

### DIFF
--- a/Controller/AclController.php
+++ b/Controller/AclController.php
@@ -12,7 +12,7 @@
  * @link          http://github.com/FMCorz/AclManager
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
- 
+
 class AclController extends AclManagerAppController {
 
 	public $paginate = array();
@@ -24,7 +24,7 @@ class AclController extends AclManagerAppController {
 	 */
 	public function beforeFilter() {
 		parent::beforeFilter();
-		
+
 		/**
 		 * Loading required Model
 		 */
@@ -32,7 +32,7 @@ class AclController extends AclManagerAppController {
 		foreach ($aros as $aro) {
 			$this->loadModel($aro);
 		}
-		
+
 		/**
 		 * Pagination
 		 */
@@ -56,7 +56,7 @@ class AclController extends AclManagerAppController {
 		$this->Session->setFlash(__("Both ACOs and AROs have been dropped"));
 		$this->redirect(array("action" => "index"));
 	}
-	
+
 	/**
 	 * Delete all permissions
 	 */
@@ -98,9 +98,9 @@ class AclController extends AclManagerAppController {
 						$this->Acl->deny($node, $action);
 					}
 				}
-			} 
+			}
 		}
-		
+
 		$model = isset($this->request->params['named']['aro']) ? $this->request->params['named']['aro'] : null;
 		if (!$model || !in_array($model, Configure::read('AclManager.aros'))) {
 			$model = Configure::read('AclManager.aros');
@@ -110,7 +110,7 @@ class AclController extends AclManagerAppController {
 		$Aro = $this->{$model};
 		$aros = $this->paginate($Aro->alias);
 		$permKeys = $this->_getKeys();
-		
+
 		/**
 		 * Build permissions info
 		 */
@@ -121,7 +121,7 @@ class AclController extends AclManagerAppController {
 			$aco =& $acos[$key];
 			$aco = array('Aco' => $data['Aco'], 'Aro' => $data['Aro'], 'Action' => array());
 			$id = $aco['Aco']['id'];
-			
+
 			// Generate path
 			if ($aco['Aco']['parent_id'] && isset($parents[$aco['Aco']['parent_id']])) {
 				$parents[$id] = $parents[$aco['Aco']['parent_id']] . '/' . $aco['Aco']['alias'];
@@ -135,7 +135,7 @@ class AclController extends AclManagerAppController {
 			foreach($aros as $aro) {
 				$aroId = $aro[$Aro->alias][$Aro->primaryKey];
 				$evaluate = $this->_evaluate_permissions($permKeys, array('id' => $aroId, 'alias' => $Aro->alias), $aco, $key);
-				
+
 				$perms[str_replace('/', ':', $acoNode)][$Aro->alias . ":" . $aroId . '-inherit'] = $evaluate['inherited'];
 				$perms[str_replace('/', ':', $acoNode)][$Aro->alias . ":" . $aroId] = $evaluate['allowed'];
 			}
@@ -144,21 +144,22 @@ class AclController extends AclManagerAppController {
 		$this->request->data = array('Perms' => $perms);
 		$this->set('aroAlias', $Aro->alias);
 		$this->set('aroDisplayField', $Aro->displayField);
+        $this->set('aroPk', $Aro->primaryKey );
 		$this->set(compact('acos', 'aros'));
 	}
-	
+
 	/**
 	 * Recursive function to find permissions avoiding slow $this->Acl->check().
 	 */
-	private function _evaluate_permissions($permKeys, $aro, $aco, $aco_index) { 
+	private function _evaluate_permissions($permKeys, $aro, $aco, $aco_index) {
 		$permissions = Set::extract("/Aro[model={$aro['alias']}][foreign_key={$aro['id']}]/Permission/.", $aco);
-		$permissions = array_shift($permissions);		
-		
+		$permissions = array_shift($permissions);
+
 		$allowed = false;
 		$inherited = false;
 		$inheritedPerms = array();
 		$allowedPerms = array();
-		
+
 		/**
 		 * Manually checking permission
 		 * Part of this logic comes from DbAcl::check()
@@ -177,7 +178,7 @@ class AclController extends AclManagerAppController {
 				$inheritedPerms[$key] = 0;
 			}
 		}
-		
+
 		if (count($allowedPerms) === count($permKeys)) {
 			$allowed = true;
 		} elseif (count($inheritedPerms) === count($permKeys)) {
@@ -193,7 +194,7 @@ class AclController extends AclManagerAppController {
 			}
 			else {
 				/**
-				 * Do not use Set::extract here. First of all it is terribly slow, 
+				 * Do not use Set::extract here. First of all it is terribly slow,
 				 * besides this we need the aco array index ($key) to cache are result.
 				 */
 				foreach ($this->acos as $key => $a) {
@@ -206,19 +207,19 @@ class AclController extends AclManagerAppController {
 				if (isset($parent_aco['evaluated'][$aro['id']])) {
 					return $parent_aco['evaluated'][$aro['id']];
 				}
-				
+
 				// Perform lookup of parent aco
 				$evaluate = $this->_evaluate_permissions($permKeys, $aro, $parent_aco, $key);
-				
+
 				// Store result in acos array so we need less recursion for the next lookup
 				$this->acos[$key]['evaluated'][$aro['id']] = $evaluate;
 				$this->acos[$key]['evaluated'][$aro['id']]['inherited'] = true;
-				
+
 				$allowed = $evaluate['allowed'];
 			}
 			$inherited = true;
 		}
-		
+
 		return array(
 			'allowed' => $allowed,
 			'inherited' => $inherited,
@@ -230,10 +231,10 @@ class AclController extends AclManagerAppController {
 	 * Sets the missing actions in the database
 	 */
 	public function update_acos() {
-		
+
 		$count = 0;
 		$knownAcos = $this->_getAcos();
-		
+
 		// Root node
 		$aco = $this->_action(array(), '');
 		if (!$rootNode = $this->Acl->Aco->node($aco)) {
@@ -241,17 +242,17 @@ class AclController extends AclManagerAppController {
 			$count++;
 		}
 		$knownAcos = $this->_removeActionFromAcos($knownAcos, $aco);
-		
+
 		// Loop around each controller and its actions
 		$allActions = $this->_getActions();
 		foreach ($allActions as $controller => $actions) {
 			if (empty($actions)) {
 				continue;
 			}
-			
+
 			$parentNode = $rootNode;
 			list($plugin, $controller) = pluginSplit($controller);
-			
+
 			// Plugin
 			$aco = $this->_action(array('plugin' => $plugin), '/:plugin/');
 			$aco = rtrim($aco, '/');		// Remove trailing slash
@@ -262,7 +263,7 @@ class AclController extends AclManagerAppController {
 			}
 			$parentNode = $newNode;
 			$knownAcos = $this->_removeActionFromAcos($knownAcos, $aco);
-			
+
 			// Controller
 			$aco = $this->_action(array('controller' => $controller, 'plugin' => $plugin), '/:plugin/:controller');
 			if (!$newNode = $this->Acl->Aco->node($aco)) {
@@ -292,7 +293,7 @@ class AclController extends AclManagerAppController {
 			$acoIds = Set::extract('/Aco/id', $knownAcos);
 			$this->Acl->Aco->deleteAll(array('Aco.id' => $acoIds));
 		}
-		
+
 		$this->Session->setFlash(sprintf(__("%d ACOs have been created/updated"), $count));
 		$this->redirect($this->request->referer());
 	}
@@ -302,32 +303,32 @@ class AclController extends AclManagerAppController {
 	 * Sets the missing AROs in the database
 	 */
 	public function update_aros() {
-	
+
 		// Debug off to enable redirect
 		Configure::write('debug', 0);
-		
+
 		$count = 0;
 		$type = 'Aro';
-			
+
 		// Over each ARO Model
 		$objects = Configure::read("AclManager.aros");
 		foreach ($objects as $object) {
-			
+
 			$Model = $this->{$object};
 
 			$items = $Model->find('all');
 			foreach ($items as $item) {
-	
+
 				$item = $item[$Model->alias];
 				$Model->create();
-				$Model->id = $item['id'];
+				$Model->id = $item[$Model->primaryKey];
 
 				try {
 					$node = $Model->node();
 				} catch (Exception $e) {
 					$node = false;
 				}
-				
+
 				// Node exists
 				if ($node) {
 					$parent = $Model->parentNode();
@@ -335,7 +336,7 @@ class AclController extends AclManagerAppController {
 						$parent = $Model->node($parent, $type);
 					}
 					$parent = isset($parent[0][$type]['id']) ? $parent[0][$type]['id'] : null;
-					
+
 					// Parent is incorrect
 					if ($parent != $node[0][$type]['parent_id']) {
 						// Remove Aro here, otherwise we've got duplicate Aros
@@ -344,10 +345,10 @@ class AclController extends AclManagerAppController {
 						$node = null;
 					}
 				}
-				
+
 				// Missing Node or incorrect
 				if (empty($node)) {
-					
+
 					// Extracted from AclBehavior::afterSave (and adapted)
 					$parent = $Model->parentNode();
 					if (!empty($parent)) {
@@ -358,7 +359,7 @@ class AclController extends AclManagerAppController {
 						'model' => $Model->name,
 						'foreign_key' => $Model->id
 					);
-					
+
 					// Creating ARO
 					$this->Acl->{$type}->create($data);
 					$this->Acl->{$type}->save();
@@ -366,7 +367,7 @@ class AclController extends AclManagerAppController {
 				}
 			}
 		}
-		
+
 		$this->Session->setFlash(sprintf(__("%d AROs have been created"), $count));
 		$this->redirect($this->request->referer());
 	}
@@ -378,7 +379,7 @@ class AclController extends AclManagerAppController {
 		$plugin = empty($request['plugin']) ? null : Inflector::camelize($request['plugin']) . '/';
 		$params = array_merge(array('controller' => null, 'action' => null, 'plugin' => null), $request);
 		$request = new CakeRequest(null, false);
-		$request->addParams($params);	
+		$request->addParams($params);
 		$authorizer = $this->_getAuthorizer();
 		return $authorizer->action($request, $path);
 	}
@@ -399,12 +400,12 @@ class AclController extends AclManagerAppController {
 
 	/**
 	 * Returns all the Actions found in the Controllers
-	 * 
+	 *
 	 * Ignores:
 	 * - protected and private methods (starting with _)
 	 * - Controller methods
 	 * - methods matching Configure::read('AclManager.ignoreActions')
-	 * 
+	 *
 	 * @return array('Controller' => array('action1', 'action2', ... ))
 	 */
 	protected function _getActions() {
@@ -413,13 +414,13 @@ class AclController extends AclManagerAppController {
 		foreach($methods as $method) {
 			$ignore[] = $method;
 		}
-		
+
 		$controllers = $this->_getControllers();
 		$actions = array();
 		foreach ($controllers as $controller) {
-		    
+
 		    list($plugin, $name) = pluginSplit($controller);
-			
+
 		    $methods = get_class_methods($name . "Controller");
 			$methods = array_diff($methods, $ignore);
 			foreach ($methods as $key => $method) {
@@ -429,7 +430,7 @@ class AclController extends AclManagerAppController {
 			}
 			$actions[$controller] = $methods;
 		}
-		
+
 		return $actions;
 	}
 
@@ -440,10 +441,10 @@ class AclController extends AclManagerAppController {
 		$acos = $this->Acl->Aco->find('all', array('order' => 'Aco.lft ASC', 'recursive' => -1));
 		$parents = array();
 		foreach ($acos as $key => $data) {
-			
+
 			$aco =& $acos[$key];
 			$id = $aco['Aco']['id'];
-			
+
 			// Generate path
 			if ($aco['Aco']['parent_id'] && isset($parents[$aco['Aco']['parent_id']])) {
 				$parents[$id] = $parents[$aco['Aco']['parent_id']] . '/' . $aco['Aco']['alias'];
@@ -467,7 +468,7 @@ class AclController extends AclManagerAppController {
 			if (!$object instanceOf ActionsAuthorize) {
 				continue;
 			}
-			$this->_authorizer = $object; 
+			$this->_authorizer = $object;
 			break;
 		}
 		if (empty($this->_authorizer)) {
@@ -484,7 +485,7 @@ class AclController extends AclManagerAppController {
 	 * @return array('Controller1', 'Plugin.Controller2')
 	 */
 	protected function _getControllers() {
-		
+
 		// Getting Cake controllers
 		$objects = array('Cake' => array());
 		$objects['Cake'] = App::objects('Controller');
@@ -492,12 +493,12 @@ class AclController extends AclManagerAppController {
 		if ($unsetIndex !== false) {
 			unset($objects['Cake'][$unsetIndex]);
 		}
-		
+
 		// App::objects does not return PagesController
 		if (!in_array('PagesController', $objects['Cake'])) {
 		    array_unshift($objects['Cake'], 'PagesController');
 		}
-		
+
 		// Getting Plugins controllers
 		$plugins = CakePlugin::loaded();
 		foreach ($plugins as $plugin) {
@@ -540,7 +541,7 @@ class AclController extends AclManagerAppController {
 		}
 		return $newKeys;
 	}
-	
+
 	/**
 	 * Returns an array without the corresponding action
 	 */

--- a/View/Acl/permissions.ctp
+++ b/View/Acl/permissions.ctp
@@ -16,7 +16,7 @@
 		<?php endforeach; ?>
 	</tr>
 <?php
-$uglyIdent = Configure::read('AclManager.uglyIdent'); 
+$uglyIdent = Configure::read('AclManager.uglyIdent');
 $lastIdent = null;
 foreach ($acos as $id => $aco) {
 	$action = $aco['Action'];
@@ -31,14 +31,15 @@ foreach ($acos as $id => $aco) {
 		?><tr class='aclmanager-ident-<?php echo $ident; ?>'><?php
 	}
 	?><td><?php echo ($ident == 1 ? "<strong>" : "" ) . ($uglyIdent ? str_repeat("&nbsp;&nbsp;", $ident) : "") . h($alias) . ($ident == 1 ? "</strong>" : "" ); ?></td>
-	<?php foreach ($aros as $aro): 
+	<?php foreach ($aros as $aro):
 		$inherit = $this->Form->value("Perms." . str_replace("/", ":", $action) . ".{$aroAlias}:{$aro[$aroAlias]['id']}-inherit");
-		$allowed = $this->Form->value("Perms." . str_replace("/", ":", $action) . ".{$aroAlias}:{$aro[$aroAlias]['id']}"); 
-		$value = $inherit ? 'inherit' : null; 
+		$allowed = $this->Form->value("Perms." . str_replace("/", ":", $action) . ".{$aroAlias}:{$aro[$aroAlias][$aroPk]}");
+		$value = $inherit ? 'inherit' : null;
 		$icon = $this->Html->image(($allowed ? 'test-pass-icon.png' : 'test-fail-icon.png')); ?>
-		<td><?php echo $icon . " " . $this->Form->select("Perms." . str_replace("/", ":", $action) . ".{$aroAlias}:{$aro[$aroAlias]['id']}", array(array('inherit' => __('Inherit'), 'allow' => __('Allow'), 'deny' => __('Deny'))), array('empty' => __('No change'), 'value' => $value)); ?></td>
+		$inherit = $this->Form->value("Perms." . str_replace("/", ":", $action) . ".{$aroAlias}:{$aro[$aroAlias][$aroPk]}-inherit");
+		<td><?php echo $icon . " " . $this->Form->select("Perms." . str_replace("/", ":", $action) . ".{$aroAlias}:{$aro[$aroAlias][$aroPk]}", array(array('inherit' => __('Inherit'), 'allow' => __('Allow'), 'deny' => __('Deny'))), array('empty' => __('No change'), 'value' => $value)); ?> </td>
 	<?php endforeach; ?>
-<?php 
+<?php
 	$lastIdent = $ident;
 }
 for ($i = 0; $i <= $lastIdent; $i++) {
@@ -57,7 +58,7 @@ echo $this->Form->end(__("Save"));
 </div>
 <div class="actions">
 	<h3><?php echo __('Manage for'); ?></h3>
-	<?php 
+	<?php
 	$aroModels = Configure::read("AclManager.aros");
 	if ($aroModels > 1): ?>
 		<ul><?php foreach ($aroModels as $aroModel): ?>


### PR DESCRIPTION
This pull request helps in the situations where the ACO object's do not have "id" has primaryKey field.
See issue #18
